### PR TITLE
Update pom.xml

### DIFF
--- a/spring-boot-web/pom.xml
+++ b/spring-boot-web/pom.xml
@@ -66,7 +66,7 @@
 		</dependency>
 		<dependency>  
 		    <groupId>org.springframework.boot</groupId>  
-		    <artifactId>spring-boot-starter-redis</artifactId>  
+		    <artifactId>spring-boot-starter-data-redis</artifactId>  
 		</dependency>  
 		<dependency>
 		    <groupId>org.springframework.session</groupId>


### PR DESCRIPTION
springboot版本升级后，不再支持原来的spring-boot-starter-redis，而改用新的spring-boot-starter-data-redis。