### PR TITLE
fix file upload err cause by parent directory not exists

### DIFF
--- a/spring-boot-file-upload/src/main/java/com/neo/controller/UploadController.java
+++ b/spring-boot-file-upload/src/main/java/com/neo/controller/UploadController.java
@@ -24,7 +24,7 @@ public class UploadController {
 
     @PostMapping("/upload") // //new annotation since 4.3
     public String singleFileUpload(@RequestParam("file") MultipartFile file,
-                                   RedirectAttributes redirectAttributes) {
+        RedirectAttributes redirectAttributes) {
         if (file.isEmpty()) {
             redirectAttributes.addFlashAttribute("message", "Please select a file to upload");
             return "redirect:uploadStatus";
@@ -33,16 +33,20 @@ public class UploadController {
         try {
             // Get the file and save it somewhere
             byte[] bytes = file.getBytes();
+            Path dir = Paths.get(UPLOADED_FOLDER);
             Path path = Paths.get(UPLOADED_FOLDER + file.getOriginalFilename());
+            // Create parent dir if not exists
+            if(!Files.exists(dir)) {
+                Files.createDirectories(dir);
+            }
             Files.write(path, bytes);
-
             redirectAttributes.addFlashAttribute("message",
-                    "You successfully uploaded '" + file.getOriginalFilename() + "'");
+                "You successfully uploaded '" + file.getOriginalFilename() + "'");
 
         } catch (IOException e) {
+            redirectAttributes.addFlashAttribute("message", "Server throw IOException");
             e.printStackTrace();
         }
-
         return "redirect:/uploadStatus";
     }
 


### PR DESCRIPTION
我在使用spring-boot-file-upload模块里的文件上传功能时发现上传文件会出现异常
![QQ截图20200909165834](https://user-images.githubusercontent.com/46752781/92577894-c10fcb80-f2bd-11ea-89a4-33ae3c758683.png)
我发现是未检查上传目录是否存在导致，因此添加了若上传目录不存在则创建的代码